### PR TITLE
Our vibe menu search icon fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -902,12 +902,12 @@ ul {
   border-radius: 20px;
   border: 1px solid transparent;
   outline: none;
-  padding: 10px 18px;
+  padding: 10px 40px 10px 18px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1) inset; 
 }
 .search-menu i{
   position: absolute;
-  right: 6px;
+  right: 12px; 
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none; /* icon stays, no click issue */


### PR DESCRIPTION
Before: 
<img width="744" height="285" alt="Screenshot 2025-11-16 at 4 02 36 PM" src="https://github.com/user-attachments/assets/bcc267de-cfec-4ef1-8551-144f1f7b2944" />

After:
<img width="630" height="282" alt="Screenshot 2025-11-16 at 4 03 42 PM" src="https://github.com/user-attachments/assets/a6474195-1b34-4aac-8f1c-6d690beab846" />
